### PR TITLE
Add PreMake5 project generation support

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -30,3 +30,8 @@
 *.exe
 *.out
 *.app
+
+# Project Generation files
+Makefile
+premake5
+premake5.lua

--- a/DeleteProjectFiles.sh
+++ b/DeleteProjectFiles.sh
@@ -1,0 +1,1 @@
+find . -type f -name 'Makefile' -delete

--- a/GenerateProjectFiles.sh
+++ b/GenerateProjectFiles.sh
@@ -1,0 +1,3 @@
+#!bin/bash/
+
+./premake5 gmake2

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 Basic NES emulator that only supports NROM (mapper 0) games.
 
-For changes to this project by @KamilKrauze go to [Changes](#changes)
+For changes to this project by [@KamilKrauze](https://github.com/KamilKrauze) go to [Changes](#changes).
 
 ## PreMake Project Files
 DISCLAIMER: I do not own the right nor contribute to the PreMake project.

--- a/README.md
+++ b/README.md
@@ -2,10 +2,12 @@
 
 Basic NES emulator that only supports NROM (mapper 0) games.
 
+For changes to this project by @KamilKrauze go to [Changes](#changes)
+
 ## PreMake Project Files
 DISCLAIMER: I do not own the right nor contribute to the PreMake project.
 
-You may use PreMake optionally to generate your project files you can also use the provided CMake files that are already provided by @filip-arch.
+You may use PreMake optionally to generate your project files you can also use the provided CMake files that are already provided by [@filip-arch](https://github.com/filip-arch).
 
 > 1. Download [PreMake5](https://premake.github.io/) and insert into the project root directory.
 > 2. You may either run the bash script `GenerateProjectFiles.sh` as shown below:

--- a/README.md
+++ b/README.md
@@ -59,7 +59,7 @@ Emulator must be given one argument, that being the .nes file it is to run e.g. 
 |Start | Enter|
 |Select | Backspace|
 
-Currently no way to remap controls other than directly modifying the controls.cpp file.
+Currently no way to remap controls other than directly modifying the `controls.cpp` file.
 
 ## Changes
 |Changes|Date|

--- a/README.md
+++ b/README.md
@@ -2,34 +2,67 @@
 
 Basic NES emulator that only supports NROM (mapper 0) games.
 
-# Compilation
+## PreMake Project Files
+DISCLAIMER: I do not own the right nor contribute to the PreMake project.
 
-To compile, run:
+You may use PreMake optionally to generate your project files you can also use the provided CMake files that are already provided by @filip-arch.
 
-cmake pathToSourceFolder/src
-make
+> 1. Download [PreMake5](https://premake.github.io/) and insert into the project root directory.
+> 2. You may either run the bash script `GenerateProjectFiles.sh` as shown below:
+> ```console
+> ./GenerateProjectFiles.sh
+> ```
+>Or you may generate the project files using the PreMake executable directly as shown below:
+> ```console
+> ./premake5 gmake2
+> ```
 
-# Running
+>### Deleting Project Files
+>For any reason that you may need to delete the project files generated using PreMake, run the `DeleteProjectFiles.sh` script as shown below:
+>```console
+>./DeleteProjectFiles.sh
+>```
+> <br>
 
-Emulator must be given one argument, that being the .nes file it is to run e.g. ./nesEmu game.nes
+## Compilation
+> ### CMake
+> To compile, run:
+> ```console
+> cmake pathToSourceFolder/src
+> make
+> ```
+> <br>
 
-# Controls
+> ### PreMake
+> If the project files have been generated using PreMake then just run in the project root directory:
+> ```console
+> make
+> ```
+> <br>
 
-Up - Up Arrow
+## Running
 
-Down - Down Arrow
+Emulator must be given one argument, that being the .nes file it is to run e.g. ``./NESEmulator`` game.nes
 
-Left - Left Arrow
+## Controls
 
-Right - Right Arrow
-
-A - Z
-
-B - X
-
-Start - Enter
-
-Select - Backspace
-
+|NES Controller|Keyboard|
+|--------------|--------|
+|Up | Up Arrow|
+|Down | Down Arrow|
+|Left | Left Arrow|
+|Right | Right Arrow|
+|A | Z|
+|B | X|
+|Start | Enter|
+|Select | Backspace|
 
 Currently no way to remap controls other than directly modifying the controls.cpp file.
+
+## Changes
+|Changes|Date|
+|---|---|
+|Added a PreMake5 lua script for project generation. | 08/12/2023 |
+|Added complenting bash scripts for generating and deleting Makefiles of this project.| 08/12/2023 |
+|Updated `README` with a better layout and PreMake instructions.| 08/12/2023 |
+|Updated `.gitignore` to ignore Makefiles and premake5.lua | 08/12/2023 |

--- a/premake5.lua
+++ b/premake5.lua
@@ -1,0 +1,23 @@
+workspace "NES-Emulator"
+    architecture "x64"
+    configurations { "Debug", "Release" }
+
+project "NES-Emulator"
+    location "src"
+    kind "ConsoleApp"
+    language "C++"
+
+    targetdir "bin/${cfg.system}-%{cfg.buildcfg}-%{cfg.architecture}"
+
+    files {
+        "./src/**.h",
+        "./src/**.cpp"
+    }
+
+    filter "configurations:Debug"
+        defines "DEBUG"
+        symbols "On"
+
+    filter "configurations:Release"
+        defines "NDEBUG"
+        optimize "On"


### PR DESCRIPTION
This is a simple addition to your project to allow users to optionally use PreMake over CMake.
This does come with a overhauled README introducing PreMake instructions and an enhanced layout.